### PR TITLE
support MS Exchange vcal files with reminder at time of event

### DIFF
--- a/vobject/icalendar.py
+++ b/vobject/icalendar.py
@@ -1913,11 +1913,11 @@ def stringToDurations(s, strict=False):
                                                sec))
                 current = ""
                 sign = None
-                week = None
-                day = None
-                hour = None
-                minute = None
-                sec = None
+                week = 0
+                day = 0
+                hour = 0
+                minute = 0
+                sec = 0
             elif char == "eof":
                 state = "end"
             else:

--- a/vobject/icalendar.py
+++ b/vobject/icalendar.py
@@ -1920,6 +1920,8 @@ def stringToDurations(s, strict=False):
                 sec = 0
             elif char == "eof":
                 state = "end"
+                if not current:
+                    second = '0'
             else:
                 state = "error"
                 error("got unexpected character reading in duration: " + s)


### PR DESCRIPTION
I created an event in MS Exchange that exported as the following vcal when sent through email or exported through OWA's web API:

    BEGIN:VCALENDAR
    METHOD:PUBLISH
    PRODID:Microsoft Exchange Server 2010
    VERSION:2.0
    BEGIN:VTIMEZONE
    TZID:FLE Standard Time
    BEGIN:STANDARD
    DTSTART:16010101T040000
    TZOFFSETFROM:+0300
    TZOFFSETTO:+0200
    RRULE:FREQ=YEARLY;INTERVAL=1;BYDAY=-1SU;BYMONTH=10
    END:STANDARD
    BEGIN:DAYLIGHT
    DTSTART:16010101T030000
    TZOFFSETFROM:+0200
    TZOFFSETTO:+0300
    RRULE:FREQ=YEARLY;INTERVAL=1;BYDAY=-1SU;BYMONTH=3
    END:DAYLIGHT
    END:VTIMEZONE
    BEGIN:VEVENT
    ORGANIZER;CN=Lauri Tirkkonen:MAILTO:lauri@example.com
    SUMMARY;LANGUAGE=en-US:test event
    DTSTART;TZID=FLE Standard Time:20190402T160000
    DTEND;TZID=FLE Standard Time:20190402T163000
    UID:040000008200E00074C5B7101A82E008000000000F3FBF812AE9D401000000000000000
     01000000018FD4114B2F2BD4FA7EB9FAE73B49A34
    CLASS:PUBLIC
    PRIORITY:5
    DTSTAMP:20190402T080323Z
    TRANSP:OPAQUE
    STATUS:CONFIRMED
    SEQUENCE:0
    LOCATION;LANGUAGE=en-US:
    X-MICROSOFT-CDO-APPT-SEQUENCE:0
    X-MICROSOFT-CDO-OWNERAPPTID:2117342223
    X-MICROSOFT-CDO-BUSYSTATUS:FREE
    X-MICROSOFT-CDO-INTENDEDSTATUS:BUSY
    X-MICROSOFT-CDO-ALLDAYEVENT:FALSE
    X-MICROSOFT-CDO-IMPORTANCE:1
    X-MICROSOFT-CDO-INSTTYPE:0
    X-MICROSOFT-DISALLOW-COUNTER:FALSE
    BEGIN:VALARM
    DESCRIPTION:REMINDER
    TRIGGER;RELATED=START:P
    ACTION:DISPLAY
    END:VALARM
    END:VEVENT
    END:VCALENDAR

it has a peculiarity: `TRIGGER;RELATED=START:P`, since I set the reminder to be at start of the event. This contradicts with https://tools.ietf.org/html/rfc5545#section-3.3.6 but what can you do...

This PR causes this peculiar case to be handled like 'PT0S'.

While here I also noticed that when a `,` is read to start another duration string, week/day/hour/minute/sec values are reinitialized to None, but they are initialized to 0 above, not None - the other commit fixes that too.