### PR TITLE
Don't assume timezone offsets to be full hours

### DIFF
--- a/vobject/icalendar.py
+++ b/vobject/icalendar.py
@@ -1693,7 +1693,8 @@ def deltaToOffset(delta):
     absDelta = abs(delta)
     hours = int(absDelta.seconds / 3600)
     hoursString = numToDigits(hours, 2)
-    minutesString = '00'
+    minutes = int(absDelta.seconds / 60) % 60
+    minutesString = numToDigits(minutes, 2)
     if absDelta == delta:
         signString = "+"
     else:


### PR DESCRIPTION
This breaks .ics files for all events in odd-offset timezones, such as Australia/Adelaide (if the client parses the provided timezones).